### PR TITLE
Increase the function execution time limit to 120 seconds

### DIFF
--- a/particles/resources/lambda.json.hbs
+++ b/particles/resources/lambda.json.hbs
@@ -1,7 +1,7 @@
 {{
     resource "m:lambda" "function"
     handler="index.handler"
-    timeout=60
+    timeout=120
     runtime="nodejs4.3"
     code=(
       partial "m:lambda" "function/s3_code"


### PR DESCRIPTION
The creation process of a new Elastigroup may take more than 60 seconds (according to the requested number of instances, etc.). If the timeout exceeded, a CloudFormation rollback process starts, and that process initiates another creation of Elastigroup which is kind of zombie to him, cause the stack no longer exists but this Elastigroup is. In order to avoid this behaviour, we increased the timeout to 120 seconds.
